### PR TITLE
Add missing dependencies to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,17 @@ classifiers = [
 ]
 
 license = { text = "GPL-3.0-or-later" }
+dependencies = [
+    "biopython>=1.81",
+    "colorlover>=0.3.0",
+    "matplotlib>=3.5.3",
+    "networkx>=2.6.3",
+    "pandas>=1.1.5",
+    "plotly>=5.18.0",
+    "scipy>=1.7.3",
+    "tqdm>=4.67.1",
+    "typer>=0.16.1",
+]
 
 
 [project.scripts]


### PR DESCRIPTION
I had to manually add biopython, colorlover, matplotlib, networkx, pandas, plotly, scipy, tqdm, typer, thus I adde those to the pyproject.toml file.